### PR TITLE
Fix Issue With Package Export Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,13 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./types/esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/@meersagor-wavesurfer-vue.js"
+      },
+      "require": "./dist/@meersagor-wavesurfer-vue.umd.cjs"
     }
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
       "require": "./dist/@meersagor-wavesurfer-vue.umd.cjs"
     }
   },
+  "types": "./dist/types/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -21,12 +21,13 @@
   "module": "./dist/@meersagor-wavesurfer-vue.js",
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/@meersagor-wavesurfer-vue.js",
-      "require": "./dist/@meersagor-wavesurfer-vue.umd.cjs"
+      "import": {
+        "types": "./types/esm/index.d.ts",
+        "default": "./esm/index.js"
+      }
     }
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./types/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   "module": "./dist/@meersagor-wavesurfer-vue.js",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/@meersagor-wavesurfer-vue.js",
       "require": "./dist/@meersagor-wavesurfer-vue.umd.cjs"
     }
   },
-  "types": "./dist/types/index.d.ts",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
### Overview
Currently there is a issue when importing this package into a project while using typescript. When importing as shown in the README the following error occurs during type-checking. 
```vue
<script setup lang="ts">
import { useWaveSurferRecorder } from '@meersagor/wavesurfer-vue'
</script>
```
```
src/components/HelloWorld.vue:2:39 - error TS7016: Could not find a declaration file for module '@meersagor/wavesurfer-vue'. '/.../node_modules/@meersagor/wavesurfer-vue/dist/@meersagor-wavesurfer-vue.js' implicitly has an 'any' type.
  There are types at '/.../node_modules/@meersagor/wavesurfer-vue/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@meersagor/wavesurfer-vue' library may need to update its package.json or typings.

2 import { useWaveSurferRecorder } from '@meersagor/wavesurfer-vue'
```



The fix is to add the types declaration to  the "export" section so that they are exposed to the consumer. For more info on this see [The Typescript Docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing). The outter "types" field can be kept for older version of Typescript

cc: @meer-sagor 