### PR TITLE
feat: add useWaveSurferRecorder and useWaveSurferRecorderStandalone p…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Meer Sagor",
   "name": "@meersagor/wavesurfer-vue",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Vue 3 composables and components for WaveSurfer.js with modular plugin architecture",
   "private": false,
   "type": "module",

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -6,6 +6,7 @@ export { useWaveSurferEnvelope } from './useWaveSurferEnvelope'
 export { useWaveSurferSpectrogram } from './useWaveSurferSpectrogram'
 export { useWaveSurferHover } from './useWaveSurferHover'
 export { useWaveSurferRegions } from './useWaveSurferRegions'
+export { useWaveSurferRecorder } from './useWaveSurferRecorder'
 
 // Standalone plugin composables (creates own WaveSurfer instance)
 export { useWaveSurferTimelineStandalone } from './useWaveSurferTimeline'
@@ -15,6 +16,7 @@ export { useWaveSurferEnvelopeStandalone } from './useWaveSurferEnvelope'
 export { useWaveSurferSpectrogramStandalone } from './useWaveSurferSpectrogram'
 export { useWaveSurferHoverStandalone } from './useWaveSurferHover'
 export { useWaveSurferRegionsStandalone } from './useWaveSurferRegions'
+export { useWaveSurferRecorderStandalone } from './useWaveSurferRecorder'
 
 // Plugin types
 export type { TimelinePluginOptions } from 'wavesurfer.js/dist/plugins/timeline'
@@ -23,3 +25,4 @@ export type { MinimapPluginOptions } from 'wavesurfer.js/dist/plugins/minimap'
 export type { EnvelopePluginOptions } from 'wavesurfer.js/dist/plugins/envelope'
 export type { SpectrogramPluginOptions } from 'wavesurfer.js/dist/plugins/spectrogram'
 export type { HoverPluginOptions } from 'wavesurfer.js/dist/plugins/hover'
+export type { RecordPluginOptions } from 'wavesurfer.js/dist/plugins/record'


### PR DESCRIPTION
…lugins

- Introduced new recording functionality with useWaveSurferRecorder and useWaveSurferRecorderStandalone.
- Enhanced TypeScript support with new interfaces for options and improved type definitions.
- Updated index.ts to export the new recorder plugins and their options.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added exports for useWaveSurferRecorder and useWaveSurferRecorderStandalone composables in index.ts</li>
<li>Added export for RecordPluginOptions type from wavesurfer.js</li>
<li>Refactored useWaveSurferRecorder to use new plugin architecture with useWaveSurferPlugin hook</li>
<li>Introduced createRecordingLogic function to share recording state and methods</li>
<li>Added useWaveSurferRecorderStandalone for creating WaveSurfer instance with recorder plugin</li>
<li>Updated function signatures to accept waveSurfer ref instead of containerRef and options</li>
<li>Improved TypeScript support with explicit type annotations</li>
</ul></div>